### PR TITLE
Upgraded to .NET 9

### DIFF
--- a/src/BlazorUnicode/BlazorUnicode.csproj
+++ b/src/BlazorUnicode/BlazorUnicode.csproj
@@ -1,34 +1,29 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
-
-	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
-		<Nullable>enable</Nullable>
-		<ImplicitUsings>enable</ImplicitUsings>
-		<ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
-		<AssemblyName>$(AssemblyName.Replace(' ', '_'))</AssemblyName>
-	</PropertyGroup>
-
-	<PropertyGroup>
-		<PackageId>$(AssemblyName)</PackageId>
-		<Product></Product>
-	</PropertyGroup>
-
-	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="7.0.3" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="7.0.3" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="7.0.0" />
-		<PackageReference Include="System.Net.Http.Json" Version="7.0.0" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<ServiceWorker Include="wwwroot\service-worker.js" PublishedContent="wwwroot\service-worker.published.js" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Folder Include="Properties\PublishProfiles\" />
-		<Folder Include="wwwroot\css\fonts\" />
-	</ItemGroup>
-
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
+    <AssemblyName>$(AssemblyName.Replace(' ', '_'))</AssemblyName>
+  </PropertyGroup>
+  <PropertyGroup>
+    <PackageId>$(AssemblyName)</PackageId>
+    <Product>
+    </Product>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.0" />
+    <PackageReference Include="System.Net.Http.Json" Version="9.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ServiceWorker Include="wwwroot\service-worker.js" PublishedContent="wwwroot\service-worker.published.js" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Properties\PublishProfiles\" />
+    <Folder Include="wwwroot\css\fonts\" />
+  </ItemGroup>
 </Project>

--- a/src/BlazorUnicodeServer/BlazorUnicodeServer.csproj
+++ b/src/BlazorUnicodeServer/BlazorUnicodeServer.csproj
@@ -1,24 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
-
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>7bf144f8-f3e8-41b4-a7ee-7e25ce8888b8</UserSecretsId>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileContext>..\..</DockerfileContext>
   </PropertyGroup>
-
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="9.0.0" />
   </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="7.0.3" />
-  </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\BlazorUnicode\BlazorUnicode.csproj" />
   </ItemGroup>
-  
 </Project>


### PR DESCRIPTION
This pull request includes updates to the target framework and package references for the `BlazorUnicode` and `BlazorUnicodeServer` projects. The most important changes include upgrading the target framework from .NET 7.0 to .NET 9.0 and updating the package references to their respective 9.0 versions.

Framework and package updates:

* [`src/BlazorUnicode/BlazorUnicode.csproj`](diffhunk://#diff-95e3037d68447b74cb794429415ddc277560e7685ab16daa03404d15c9d6daa2L2-L33): Upgraded the target framework from `net7.0` to `net9.0` and updated all package references to version 9.0.
* [`src/BlazorUnicodeServer/BlazorUnicodeServer.csproj`](diffhunk://#diff-66ae38b1724446eadb61dee98e8484def3328bf86a8360a926cec71438e2d094L2-L23): Updated the target framework from `net7.0` to `net9.0` and replaced the package reference for `Microsoft.AspNetCore.Components.WebAssembly.Server` to version 9.0.